### PR TITLE
FIX: pthreads: also install "pthreads.lib"

### DIFF
--- a/ports/pthreads/portfile.cmake
+++ b/ports/pthreads/portfile.cmake
@@ -32,3 +32,8 @@ foreach(HEADER ${HEADERS})
 endforeach()
 
 file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/pthreads RENAME copyright)
+file(RENAME 
+    ${CURRENT_PACKAGES_DIR}/lib/pthreadsVC2.lib
+    DESTINATION ${CURRENT_PACKAGES_DIR}/lib
+    RENAME pthreads.lib
+)

--- a/ports/pthreads/portfile.cmake
+++ b/ports/pthreads/portfile.cmake
@@ -32,7 +32,7 @@ foreach(HEADER ${HEADERS})
 endforeach()
 
 file(INSTALL ${SOURCE_PATH}/COPYING DESTINATION ${CURRENT_PACKAGES_DIR}/share/pthreads RENAME copyright)
-file(RENAME 
+file(COPY 
     ${CURRENT_PACKAGES_DIR}/lib/pthreadsVC2.lib
     DESTINATION ${CURRENT_PACKAGES_DIR}/lib
     RENAME pthreads.lib


### PR DESCRIPTION
The current pthreads port installed a library file with a name that other projects don't automatically pick up. This adds a new library file with the standard pthreads name, but preserves backward compatibility for other ports that already have a dependency on this project.